### PR TITLE
Fix #216: add throws clause for checked exception

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/RepositoryHandle.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/RepositoryHandle.java
@@ -5,6 +5,7 @@ import org.jfrog.artifactory.client.model.ItemPermission;
 import org.jfrog.artifactory.client.model.ReplicationStatus;
 import org.jfrog.artifactory.client.model.Repository;
 import java.io.File;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Set;
 
@@ -39,7 +40,7 @@ public interface RepositoryHandle {
 
     Replications getReplications();
 
-    boolean isFolder(String path);
+    boolean isFolder(String path) throws IOException;
 
     boolean exists();
 }


### PR DESCRIPTION
RepositoryHandle#isFolder throws checked IOException without declaring,
resulting in a compile error when the client code tries to handle it.