### PR TITLE
Change Artifactory to implement AutoClosable

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/Artifactory.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Artifactory.java
@@ -11,7 +11,7 @@ import java.net.MalformedURLException;
  * @since 25/07/12
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public interface Artifactory extends ApiInterface {
+public interface Artifactory extends ApiInterface, AutoCloseable {
 
     String API_BASE = "/api";
 


### PR DESCRIPTION
Let Artifactory implement AutoClosable to make it possible to use it with the try-with-resources construct:

```
try (Artifactory artifactory = ArtifactoryClientBuilder.create()
                .setUrl(url)
                .setUsername(username)
                .setPassword(password)
                .build()) {
	   // ...
}
```

It makes the Artifactory API easier to use with the [ArtifactoryBuildInfoClient](https://github.com/jfrog/build-info/blob/c9d6d76acb0ff8fdffad8a7b855338903617ec92/build-info-extractor/src/main/java/org/jfrog/build/extractor/clientConfiguration/client/ArtifactoryBuildInfoClient.java), which already implements this API.


