### PR TITLE
Fix 206: Improve error handling

### DIFF
--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/CopyMoveException.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/CopyMoveException.groovy
@@ -2,17 +2,26 @@ package org.jfrog.artifactory.client.impl
 
 import org.jfrog.artifactory.client.model.CopyMoveResultReport
 
+import java.util.stream.Collectors
+
 /**
  * Created by Jeka on 05/11/13.
  */
-class CopyMoveException extends RuntimeException {
+public class CopyMoveException extends RuntimeException {
     private CopyMoveResultReport copyMoveResultReport
 
     CopyMoveException(CopyMoveResultReport copyMoveResultReport) {
+        super(concatMessages(copyMoveResultReport))
         this.copyMoveResultReport = copyMoveResultReport
     }
 
     CopyMoveResultReport getCopyMoveResultReport() {
         return copyMoveResultReport
+    }
+
+    private static String concatMessages(CopyMoveResultReport copyMoveResultReport) {
+        copyMoveResultReport.getMessages().stream()
+                .map { result -> result.getMessage() }
+                .collect(Collectors.joining(", "))
     }
 }

--- a/services/src/main/java/org/jfrog/artifactory/client/impl/util/Util.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/impl/util/Util.java
@@ -8,10 +8,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.*;
 import com.fasterxml.jackson.databind.module.SimpleAbstractTypeResolver;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import com.fasterxml.jackson.core.JsonParseException;
 import org.apache.commons.io.IOUtils;
 import org.apache.http.Consts;
 import org.apache.http.HttpResponse;
 import org.apache.http.entity.ContentType;
+import org.apache.http.util.EntityUtils;
 import org.jfrog.artifactory.client.ArtifactoryRequest;
 import org.jfrog.artifactory.client.impl.jackson.RepositoryMixIn;
 import org.jfrog.artifactory.client.impl.jackson.RepositorySettingsMixIn;
@@ -44,7 +46,8 @@ public class Util {
             objectMapper.registerModule(module);
         }
 
-        return objectMapper.readValue(httpResponse.getEntity().getContent(), object);
+        String content = EntityUtils.toString(httpResponse.getEntity(), "UTF-8");
+        return objectMapper.readValue(content, object);
     }
 
     public static void configureObjectMapper(ObjectMapper objectMapper) {


### PR DESCRIPTION
Fix issues in #206:

- When a `CopyMoveException` is created, populate its `message` field with the exception details, so loggers will pick it up properly.
- Changed the JSON parsing to be non-streaming, but to read the whole String content up-front. This way Jackson will report the original content when the parsing fails, providing information about the nature of the problem.