### PR TITLE
Support retry handler

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/Artifactory.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Artifactory.java
@@ -11,7 +11,7 @@ import java.net.MalformedURLException;
  * @since 25/07/12
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public interface Artifactory extends ApiInterface {
+public interface Artifactory extends ApiInterface, Closeable {
 
     String API_BASE = "/api";
 

--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ subprojects {
     dependencies {
         compile 'org.apache.httpcomponents:httpcore:4.4.1'
         compile 'org.apache.httpcomponents:httpclient:4.5'
-        compile group: 'commons-lang', name: 'commons-lang', version: '2.3'
+        compile group: 'commons-lang', name: 'commons-lang', version: '2.6'
         compile 'com.fasterxml.jackson.core:jackson-core:2.9.5'
         compile 'com.fasterxml.jackson.core:jackson-databind:2.9.5'
         compile 'com.fasterxml.jackson.core:jackson-annotations:2.4.6'

--- a/httpClient/src/main/java/org/jfrog/artifactory/client/httpClient/http/HttpBuilderBase.java
+++ b/httpClient/src/main/java/org/jfrog/artifactory/client/httpClient/http/HttpBuilderBase.java
@@ -3,6 +3,7 @@ package org.jfrog.artifactory.client.httpClient.http;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.*;
 import org.apache.http.auth.*;
+import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.config.AuthSchemes;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.config.Registry;
@@ -156,6 +157,11 @@ public abstract class HttpBuilderBase<T extends HttpBuilderBase> {
                     new AuthScope(defaultHost.getHostName(), AuthScope.ANY_PORT, AuthScope.ANY_REALM);
             credsProvider.setCredentials(authscope, new UsernamePasswordCredentials(username, password));
         }
+        return self();
+    }
+
+    public T retryHandler(HttpRequestRetryHandler retryHandler) {
+        builder.setRetryHandler(retryHandler);
         return self();
     }
 

--- a/services/src/main/groovy/org/jfrog/artifactory/client/ArtifactoryClientBuilder.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/ArtifactoryClientBuilder.java
@@ -1,6 +1,7 @@
 package org.jfrog.artifactory.client;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.http.client.HttpRequestRetryHandler;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.jfrog.artifactory.client.httpClient.http.HttpBuilderBase;
@@ -30,6 +31,7 @@ public class ArtifactoryClientBuilder {
     private String userAgent;
     private boolean ignoreSSLIssues;
     private String accessToken;
+    private HttpRequestRetryHandler retryHandler;
 
     protected ArtifactoryClientBuilder() {
         super();
@@ -87,6 +89,11 @@ public class ArtifactoryClientBuilder {
         return this;
     }
 
+    public ArtifactoryClientBuilder setRetryHandler(HttpRequestRetryHandler retryHandler) {
+        this.retryHandler = retryHandler;
+        return this;
+    }
+
     private CloseableHttpClient createClientBuilder(URI uri) {
         ArtifactoryHttpClient artifactoryHttpClient = new ArtifactoryHttpClient();
         artifactoryHttpClient.hostFromUrl(uri.toString());
@@ -110,6 +117,10 @@ public class ArtifactoryClientBuilder {
 
         if (socketTimeout != null) {
             artifactoryHttpClient.socketTimeout(socketTimeout);
+        }
+
+        if (retryHandler != null) {
+            artifactoryHttpClient.retryHandler(retryHandler);
         }
 
         artifactoryHttpClient.trustSelfSignCert(!ignoreSSLIssues);

--- a/services/src/main/resources/artifactory.client.release.properties
+++ b/services/src/main/resources/artifactory.client.release.properties
@@ -1,1 +1,1 @@
-version=2.8.0
+version=2.8.x-SNAPSHOT


### PR DESCRIPTION
## Purpose

Use automated retry handler for handling intermittent connection issues

## Changes

1. Add hook for a retry handler
2. Have the Artifactory interface implement Closeable to be able to use try-with-resources
3. Upgrade commons lang version to avoid security vulnerabilities in the lower version

## Usage

Sample usage of a retry handler:

```
    HttpRequestRetryHandler retryHandler = (exception, executionCount, context) -> {
      // Do not retry if over max retry count
      log.info("Attempt {} of {}", executionCount, maxRetry);
      return executionCount <= maxRetry && !(exception instanceof UnknownHostException)
          && !(exception instanceof SSLException);
    };
    return ArtifactoryClientBuilder.create().setUrl(this.getArtifactoryApiEndpoint())
        .setUsername(this.getArtifactoryUserName())
        .setPassword(this.getArtifactoryPassword())
        .setConnectionTimeout(toIntExact(connectionTimeout.toMillis()))
        .setSocketTimeout(toIntExact(socketTimeout.toMillis()))
        .setRetryHandler(retryHandler)
        .build();
```