### PR TITLE
 Added support for API key via dedicated header

### DIFF
--- a/services/src/main/groovy/org/jfrog/artifactory/client/ArtifactoryClientBuilder.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/ArtifactoryClientBuilder.java
@@ -30,6 +30,7 @@ public class ArtifactoryClientBuilder {
     private String userAgent;
     private boolean ignoreSSLIssues;
     private String accessToken;
+    private String apiKey;
 
     protected ArtifactoryClientBuilder() {
         super();
@@ -87,12 +88,17 @@ public class ArtifactoryClientBuilder {
         return this;
     }
 
+    public ArtifactoryClientBuilder setApiKey(String apiKey) {
+        this.apiKey = apiKey;
+        return this;
+    }
+
+
     private CloseableHttpClient createClientBuilder(URI uri) {
         ArtifactoryHttpClient artifactoryHttpClient = new ArtifactoryHttpClient();
         artifactoryHttpClient.hostFromUrl(uri.toString());
 
-
-        if (StringUtils.isEmpty(accessToken)) {
+        if (StringUtils.isEmpty(accessToken) && StringUtils.isEmpty(apiKey)) {
             artifactoryHttpClient.authentication(username, password);
         }
 
@@ -134,7 +140,7 @@ public class ArtifactoryClientBuilder {
 
         CloseableHttpClient closeableHttpClient = createClientBuilder(uri);
 
-        return new ArtifactoryImpl(closeableHttpClient, url, userAgent, username, accessToken);
+        return new ArtifactoryImpl(closeableHttpClient, url, userAgent, username, accessToken, apiKey);
     }
 
     private static String getUserAgent() throws IOException {

--- a/services/src/main/resources/artifactory.client.release.properties
+++ b/services/src/main/resources/artifactory.client.release.properties
@@ -1,1 +1,1 @@
-version=2.8.1
+version=2.8.x-SNAPSHOT


### PR DESCRIPTION
From docs around ways to authenticate with the API (https://www.jfrog.com/confluence/display/RTF/Artifactory+REST+API#ArtifactoryRESTAPI-SystemInfo):

```
* Basic authentication using your username and API Key.
* Using a dedicated header (X-JFrog-Art-Api) with your API Key.
```

While basic authentication with username/API key is supported, I believe it would be cleaner to use the API key header and also that reduces the need on the client to do the base64  encoding.