### PR TITLE
Allow full configuration of Apache HTTP Client SSLContext

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ Artifactory artifactory = ArtifactoryClientBuilder.create()
     .setPassword("password")
     .build();
 ```
+
+Trusting your own self-signed certificates without ignoring any SSL issue:
+```
+Artifactory artifactory = ArtifactoryClientBuilder.create()
+    .setUrl("ArtifactoryUrl")
+    .setUsername("username")
+    .setPassword("password")
+    .setSslContextBuilder(SSLContexts.custom()
+        .loadTrustMaterial( <your trust strategy here> ))
+    .build();
+```
+
 #### Uploading and downloading artifacts
 
 ##### Uploading an Artifacts

--- a/httpClient/src/main/java/org/jfrog/artifactory/client/httpClient/http/HttpBuilderBase.java
+++ b/httpClient/src/main/java/org/jfrog/artifactory/client/httpClient/http/HttpBuilderBase.java
@@ -46,7 +46,7 @@ public abstract class HttpBuilderBase<T extends HttpBuilderBase> {
     private JFrogAuthScheme chosenAuthScheme = JFrogAuthScheme.BASIC; //Signifies what auth scheme will be used by the client
     private boolean cookieSupportEnabled = false;
     private boolean trustSelfSignCert = false;
-    protected SSLContextBuilder sslContextBuilder;
+    private SSLContextBuilder sslContextBuilder;
     private int maxConnectionsTotal = DEFAULT_MAX_CONNECTIONS;
     private int maxConnectionsPerRoute = DEFAULT_MAX_CONNECTIONS;
     private int connectionPoolTimeToLive = CONNECTION_POOL_TIME_TO_LIVE;
@@ -299,11 +299,11 @@ public abstract class HttpBuilderBase<T extends HttpBuilderBase> {
         try {
             SSLContextBuilder sslBuilder = sslContextBuilder;
             if (trustSelfSignCert) {
-                if (sslBuilder != null) {
-                    throw new IllegalStateException("Cannot configure both SSLContextBuilder and TrustSelfSignCert");
+                if (sslBuilder == null) {
+                    sslBuilder = SSLContexts.custom();
                 }
                 // trust any self signed certificate
-                sslBuilder = SSLContexts.custom().loadTrustMaterial(TrustSelfSignedMultiChainStrategy.INSTANCE);
+                sslBuilder.loadTrustMaterial(TrustSelfSignedMultiChainStrategy.INSTANCE);
             }
             if (sslBuilder != null) {
                 sslContext = sslBuilder.build();

--- a/httpClient/src/main/java/org/jfrog/artifactory/client/httpClient/http/HttpBuilderBase.java
+++ b/httpClient/src/main/java/org/jfrog/artifactory/client/httpClient/http/HttpBuilderBase.java
@@ -46,6 +46,7 @@ public abstract class HttpBuilderBase<T extends HttpBuilderBase> {
     private JFrogAuthScheme chosenAuthScheme = JFrogAuthScheme.BASIC; //Signifies what auth scheme will be used by the client
     private boolean cookieSupportEnabled = false;
     private boolean trustSelfSignCert = false;
+    protected SSLContextBuilder sslContextBuilder;
     private int maxConnectionsTotal = DEFAULT_MAX_CONNECTIONS;
     private int maxConnectionsPerRoute = DEFAULT_MAX_CONNECTIONS;
     private int connectionPoolTimeToLive = CONNECTION_POOL_TIME_TO_LIVE;
@@ -133,6 +134,15 @@ public abstract class HttpBuilderBase<T extends HttpBuilderBase> {
      */
     public T trustSelfSignCert(boolean trustSelfSignCert) {
         this.trustSelfSignCert = trustSelfSignCert;
+        return self();
+    }
+
+    /**
+     * @param sslContextBuilder SSLContext builder
+     * @return {@link T}
+     */
+    public T sslContextBuilder(SSLContextBuilder sslContextBuilder) {
+        this.sslContextBuilder = sslContextBuilder;
         return self();
     }
 
@@ -287,8 +297,11 @@ public abstract class HttpBuilderBase<T extends HttpBuilderBase> {
     private SSLContext buildSslContext() {
         SSLContext sslContext = null;
         try {
-            SSLContextBuilder sslBuilder = null;
+            SSLContextBuilder sslBuilder = sslContextBuilder;
             if (trustSelfSignCert) {
+                if (sslBuilder != null) {
+                    throw new IllegalStateException("Cannot configure both SSLContextBuilder and TrustSelfSignCert");
+                }
                 // trust any self signed certificate
                 sslBuilder = SSLContexts.custom().loadTrustMaterial(TrustSelfSignedMultiChainStrategy.INSTANCE);
             }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/ArtifactoryClientBuilder.java
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/ArtifactoryClientBuilder.java
@@ -3,6 +3,8 @@ package org.jfrog.artifactory.client;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.ssl.SSLContextBuilder;
+
 import org.jfrog.artifactory.client.httpClient.http.HttpBuilderBase;
 import org.jfrog.artifactory.client.impl.ArtifactoryImpl;
 import org.jfrog.artifactory.client.impl.util.ArtifactoryHttpClient;
@@ -29,6 +31,7 @@ public class ArtifactoryClientBuilder {
     private ProxyConfig proxy;
     private String userAgent;
     private boolean ignoreSSLIssues;
+    private SSLContextBuilder sslContextBuilder;
     private String accessToken;
 
     protected ArtifactoryClientBuilder() {
@@ -82,6 +85,11 @@ public class ArtifactoryClientBuilder {
         return this;
     }
 
+    public ArtifactoryClientBuilder setSslContextBuilder(SSLContextBuilder sslContextBuilder) {
+        this.sslContextBuilder = sslContextBuilder;
+        return this;
+    }
+
     public ArtifactoryClientBuilder setAccessToken(String accessToken) {
         this.accessToken = accessToken;
         return this;
@@ -112,7 +120,12 @@ public class ArtifactoryClientBuilder {
             artifactoryHttpClient.socketTimeout(socketTimeout);
         }
 
-        artifactoryHttpClient.trustSelfSignCert(!ignoreSSLIssues);
+        if (sslContextBuilder != null) {
+            artifactoryHttpClient.sslContextBuilder(sslContextBuilder);
+        }
+        else {
+            artifactoryHttpClient.trustSelfSignCert(!ignoreSSLIssues);
+        }
         return artifactoryHttpClient.build();
     }
 
@@ -175,6 +188,10 @@ public class ArtifactoryClientBuilder {
 
     public boolean isIgnoreSSLIssues() {
         return ignoreSSLIssues;
+    }
+
+    public SSLContextBuilder getSslContextBuilder() {
+        return sslContextBuilder;
     }
 
     public String getAccessToken() {

--- a/services/src/main/resources/artifactory.client.release.properties
+++ b/services/src/main/resources/artifactory.client.release.properties
@@ -1,1 +1,1 @@
-version=2.8.1
+version=2.8.x-SNAPSHOT


### PR DESCRIPTION
We would like to enable the verification of self-signed certificates (not just ignore any SSL issue).
And we would like to do this without having to modify the JVM default trust-store.

One "easy" to achieve this seems to be configuring the SSL context of the internal Apache HTTP Client.