### PR TITLE
Encode keys and values for file upload properties 

### DIFF
--- a/services/src/main/java/org/jfrog/artifactory/client/impl/ArtifactBase.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/impl/ArtifactBase.java
@@ -1,8 +1,12 @@
 package org.jfrog.artifactory.client.impl;
 
-import org.jfrog.artifactory.client.Artifact;
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+
+import org.jfrog.artifactory.client.Artifact;
 
 /**
  * Created by eyalb on 21/06/2018.
@@ -28,11 +32,13 @@ public abstract class ArtifactBase<T extends Artifact> implements Artifact<T> {
         return this;
     }
 
-    protected String parseParams(HashMap<String, Object[]> props, String delimiter) {
+    protected String parseParams(HashMap<String, Object[]> props, String delimiter) throws UnsupportedEncodingException {
         StringBuilder sb = new StringBuilder();
         for (Map.Entry<String, Object[]> entry : props.entrySet()) {
+            String urlEncodedKey = URLEncoder.encode(entry.getKey(), StandardCharsets.UTF_8.toString());
             for (Object value : entry.getValue()) {
-                sb.append(";").append(entry.getKey()).append(delimiter).append(value);
+                String urlEncodedValue = URLEncoder.encode(String.valueOf(value), StandardCharsets.UTF_8.toString());
+                sb.append(";").append(urlEncodedKey).append(delimiter).append(urlEncodedValue);
             }
         }
         return sb.toString();

--- a/services/src/test/java/org/jfrog/artifactory/client/DownloadUploadTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/DownloadUploadTests.java
@@ -188,6 +188,13 @@ public class DownloadUploadTests extends ArtifactoryTestsBase {
         assertTrue(curlAndStrip("api/storage/" + localRepository.getKey() + "/" + PATH + "?properties").contains("{\"build\":[\"28\"],\"colors\":[\"red\"],\"released\":[\"false\"]}"));
     }
 
+    @Test(dependsOnMethods = "testUploadWithSingleProperty")
+    public void testUploadWithUrlUnsafeProperties() throws IOException {
+        artifactory.repository(localRepository.getKey()).upload(PATH, this.getClass().getResourceAsStream("/sample.txt"))
+                .withProperty("contains.url.unsafe", "test+value").doUpload();
+        assertTrue(curlAndStrip("api/storage/" + localRepository.getKey() + "/" + PATH + "?properties").contains("{\"contains.url.unsafe\":[\"test+value\"]}"));
+    }
+
     //TODO (jb) enable once RTFACT-5126 is fixed
     @Test(enabled = false, dependsOnMethods = "testUploadWithSingleProperty")
     public void testUploadWithMultiplePropertyValues() throws IOException {


### PR DESCRIPTION
Fixes issues #263 and #251. With this change the property keys are also URL encoded.