### PR TITLE
Use maven-2-default layout instead of gradle-default

### DIFF
--- a/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/GradleRepositorySettingsImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/GradleRepositorySettingsImpl.java
@@ -8,7 +8,7 @@ import org.jfrog.artifactory.client.model.repository.settings.GradleRepositorySe
  * @author Ivan Vasylivskyi (ivanvas@jfrog.com)
  */
 public class GradleRepositorySettingsImpl extends MavenRepositorySettingsImpl implements GradleRepositorySettings {
-    private static String defaultLayout = "gradle-default";
+    private static String defaultLayout = "maven-2-default";
 
     public GradleRepositorySettingsImpl() {
         super(defaultLayout);


### PR DESCRIPTION
Replacing gradle-default repository layout with maven-2-default due to gradle-default deprecation.