### PR TITLE
UploadableArtifact withSize()

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/UploadableArtifact.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/UploadableArtifact.java
@@ -16,6 +16,8 @@ public interface UploadableArtifact extends Artifact<UploadableArtifact> {
 
     String doUploadAndExplode(boolean atomic);
 
+    UploadableArtifact withSize(long size);
+
     UploadableArtifact withListener(UploadListener listener);
 
     UploadableArtifact bySha1Checksum();


### PR DESCRIPTION
In the RepositoryHandle class one can upload a file with either a given InputStream or a java.io.File
This is rather handy, because one can use the InputStream if he wants to avoid using the java.io library and use the java.nio instead, but also because the inputstream opening-closing is rather messy in this API, and this way the user can control the process.

However, if we try to attach a progress listener to the UploadableArtifact with the withListener(listener) method, an IllegalState exception is thrown asking the user to upload a java.io.File instead of the InputStream because it does not know the content size.

This can be solved rather easily just by setting the content size for the UploadableArtifact before calling the doUpload() method.

This PR adds a new method to the UploadArtifact -> withSize(long size):
Given a listener is attached to the UploadArtifact
- if java.io.File is given, then a progress recorder is created with the file.length() size
- if an InputStream is given and the size is set by the user, then a progress recorder is created with the given size
- if an  InputStream is given and the size was not set by the user, then an IllegalStateException is thrown asking the user to either set the size or to use java.io.File to upload