### PR TITLE
Remove tests that change the conf descriptor

### DIFF
--- a/services/src/test/java/org/jfrog/artifactory/client/RestCallTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/RestCallTests.java
@@ -3,7 +3,6 @@ package org.jfrog.artifactory.client;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.HttpStatus;
 import org.jfrog.artifactory.client.impl.ArtifactoryRequestImpl;
 import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
@@ -116,38 +115,6 @@ public class RestCallTests extends ArtifactoryTestsBase {
         assertTrue(buildInfo.containsKey("version"));
         assertTrue(buildInfo.containsKey("name"));
         assertTrue(buildInfo.containsKey("number"));
-    }
-
-    @Test
-    public void testPatchProxy() throws Exception {
-        final String proxyName = "proxy1";
-        String yaml = "proxies:\n"
-                + "  " + proxyName + ":\n"
-                + "    host: hostproxy1\n"
-                + "    port: 0 \n";
-        String artifactory7Yaml = yaml + "    platformDefault: false\n";
-
-        ArtifactoryRequest patchProxyRequest = new ArtifactoryRequestImpl()
-                .method(ArtifactoryRequest.Method.PATCH)
-                .apiUrl("api/system/configuration")
-                .requestType(ArtifactoryRequest.ContentType.YAML)
-                .requestBody(artifactory7Yaml);
-        ArtifactoryResponse response = artifactory.restCall(patchProxyRequest); // First, try Artifactory 7 style yaml
-
-        assertNotNull(response);
-        if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK) { // If status != 200, try Artifactory 6 style yaml
-            String artifactory6Yaml = yaml + "    defaultProxy: false\n";
-            response = artifactory.restCall(patchProxyRequest.requestBody(artifactory6Yaml));
-            assertNotNull(response);
-            assertEquals(HttpStatus.SC_OK, response.getStatusLine().getStatusCode());
-        }
-
-        String updatedXml = artifactory.system().configuration();
-        assertTrue(updatedXml.contains(proxyName));
-
-        // Remove proxy
-        patchProxyRequest.requestBody("proxies:\n  " + proxyName + ": null\n");
-        artifactory.restCall(patchProxyRequest);
     }
 
     @Test(dependsOnMethods = {"testGetBuildInfo"})

--- a/services/src/test/java/org/jfrog/artifactory/client/SystemTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/SystemTests.java
@@ -36,55 +36,6 @@ public class SystemTests extends ArtifactoryTestsBase {
     }
 
     @Test
-    public void testDownloadOfSystemConfiguration() {
-        String xml = artifactory.system().configuration();
-        assertTrue(xml.contains("backups"));
-        assertTrue(xml.contains("localRepositories"));
-        assertTrue(xml.contains("repoLayouts"));
-    }
-
-    @Test
-    public void testUploadOfSystemConfiguration() {
-        String oldXml = artifactory.system().configuration();
-        String changedXml = oldXml.replace("<excludeBuilds>false</excludeBuilds>", "<excludeBuilds>true</excludeBuilds>");
-
-        artifactory.system().configuration(changedXml);
-
-        String updatedXml = artifactory.system().configuration();
-        assertTrue(updatedXml.contains("backups"));
-        assertTrue(updatedXml.contains("localRepositories"));
-        assertTrue(updatedXml.contains("repoLayouts"));
-
-        // Restore
-        String restoredXml = updatedXml.replace("<excludeBuilds>true</excludeBuilds>", "<excludeBuilds>false</excludeBuilds>");
-        artifactory.system().configuration(restoredXml);
-    }
-
-    @Test
-    public void testPatchOfProxy() {
-        final String proxyName = "proxy1";
-        String yaml = "proxies:\n"
-                + "  " + proxyName + ":\n"
-                + "    host: hostproxy1\n"
-                + "    port: 0 \n";
-        String artifactory7Yaml = yaml + "    platformDefault: false\n";
-        artifactory.system().yamlConfiguration(artifactory7Yaml); // First, try Artifactory 7 style yaml
-
-        String updatedXml = artifactory.system().configuration();
-        if (!updatedXml.contains(proxyName)) { // If request failed, try Artifactory 6 style yaml
-            String artifactory6Yaml = yaml + "    defaultProxy: false\n";
-            artifactory.system().yamlConfiguration(artifactory6Yaml);
-            updatedXml = artifactory.system().configuration();
-            assertTrue(updatedXml.contains(proxyName));
-        }
-
-        // Restore
-        String deleteProxy = "proxies:\n"
-                + "  " + proxyName + ": null\n";
-        artifactory.system().yamlConfiguration(deleteProxy);
-    }
-
-    @Test
     public void testSystemInfo() {
         SystemInfo info = artifactory.system().info();
         Assert.assertNotNull(info);


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----
The following APIs are no longer supported in Artifactory SaaS and therefore we should remove their tests:
```
POST /api/system/configuration
PATCH /api/system/configuration
```