### PR TITLE
Implement SecurityBuildersImpl#builderFrom(PermissionTarget)

### DIFF
--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/SecurityBuildersImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/SecurityBuildersImpl.java
@@ -35,7 +35,14 @@ public class SecurityBuildersImpl implements SecurityBuilders {
     }
 
     public PermissionTargetBuilder builderFrom(PermissionTarget from) {
-        return null;//TODO implement copy builder for PermissionTarget
+        PermissionTargetBuilder builder = new PermissionTargetBuilderImpl();
+        builder
+            .name(from.getName())
+            .includesPattern(from.getIncludesPattern())
+            .excludesPattern(from.getExcludesPattern())
+            .repositories(from.getRepositories().toArray(new String[0]))
+            .principals(from.getPrincipals());
+        return builder;
     }
 
     public PrincipalsBuilder principalsBuilder() {


### PR DESCRIPTION
This patch resolves what appears to be a long standing TODO to implement
this method. A test to check for exhaustiveness of the builder is
included, though this may be less valuable.

- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----
