### PR TITLE
Fix getRepositorySettingsForTypeTest

### DIFF
--- a/services/src/test/groovy/org/jfrog/artifactory/client/UtilTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/UtilTests.groovy
@@ -1,6 +1,5 @@
 package org.jfrog.artifactory.client
 
-import org.hamcrest.CoreMatchers
 import org.jfrog.artifactory.client.impl.util.Util
 import org.jfrog.artifactory.client.model.impl.PackageTypeImpl
 import org.jfrog.artifactory.client.model.repository.settings.impl.BowerRepositorySettingsImpl
@@ -13,8 +12,8 @@ class UtilTests {
 
     @Test(groups = "utilTests")
     void getRepositorySettingsForTypeTest() {
-        assertEquals(Util.getRepositorySettingsClassForPackageType(PackageTypeImpl.bower), CoreMatchers.equalTo(BowerRepositorySettingsImpl.class))
-        assertEquals(Util.getRepositorySettingsClassForPackageType(PackageTypeImpl.maven), CoreMatchers.equalTo(MavenRepositorySettingsImpl.class))
+        assertEquals(Util.getRepositorySettingsClassForPackageType(PackageTypeImpl.bower), BowerRepositorySettingsImpl.class)
+        assertEquals(Util.getRepositorySettingsClassForPackageType(PackageTypeImpl.maven), MavenRepositorySettingsImpl.class)
     }
 
 }


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----

Fix the following exception in the test:
```
java.lang.AssertionError: expected [<class org.jfrog.artifactory.client.model.repository.settings.impl.BowerRepositorySettingsImpl>] but found [class org.jfrog.artifactory.client.model.repository.settings.impl.BowerRepositorySettingsImpl]
```