### PR TITLE
Make jfrog related projects transitive

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -52,7 +52,7 @@ nexusPublishing {
 }
 
 subprojects {
-    apply plugin: 'java'
+    apply plugin: 'java-library'
     apply plugin: 'signing'
 
     sourceCompatibility = 1.8
@@ -67,7 +67,7 @@ subprojects {
         implementation 'com.fasterxml.jackson.core:jackson-core:2.12.6'
         implementation 'com.fasterxml.jackson.core:jackson-databind:2.12.6'
         implementation 'com.fasterxml.jackson.core:jackson-annotations:2.12.6'
-        implementation 'org.jfrog.filespecs:file-specs-java:1.1.1'
+        api 'org.jfrog.filespecs:file-specs-java:1.1.1'
     }
 
     task sourcesJar(type: Jar, dependsOn: classes) {
@@ -120,13 +120,6 @@ subprojects {
                             appendNode('developerConnection', 'scm:git:git@github.com:jfrog/artifactory-client-java.git')
                             appendNode('url', 'https://github.com/jfrog/artifactory-client-java')
                         }
-                    }
-                    asNode().dependencies.'*'.findAll() {
-                        it.scope.text() == 'runtime' && project.configurations.compile.allDependencies.find { dep ->
-                            dep.name == it.artifactId.text()
-                        }
-                    }.each() {
-                        it.scope*.value = 'compile'
                     }
                 }
             }

--- a/services/build.gradle
+++ b/services/build.gradle
@@ -1,8 +1,8 @@
 apply plugin: 'groovy'
 
 dependencies {
-    implementation project(':artifactory-java-client-api')
-    implementation project(':artifactory-java-client-httpClient')
+    api project(':artifactory-java-client-api')
+    api project(':artifactory-java-client-httpClient')
     implementation addGroovy('groovy')
     implementation addSlf4J('slf4j-api')
     implementation addSlf4J('log4j-over-slf4j')


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----

This change https://github.com/jfrog/artifactory-client-java/pull/340/files#diff-74048ce29e9b763ea6209f3e3ee168405f8eb8a8a3a95210359623abac03e46cR4-R5 made the `artifactory-java-client-api` and `artifactory-java-client-httpClient` dependencies to have `runtime` scope in the built pom.xml, instead of `compile`. 
As a result, those projects are not getting downloaded by default, when using `artifactory-java-client-services` as a dependency.