### PR TITLE
Add Docker tag retention attribute for Docker repos - followup

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/DockerRepositorySettings.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/DockerRepositorySettings.java
@@ -12,7 +12,10 @@ public interface DockerRepositorySettings extends RepositorySettings {
     // ** local ** //
 
     DockerApiVersion getDockerApiVersion();
+
     Integer getMaxUniqueTags();
+
+    Integer getDockerTagRetention();
 
     // ** remote ** //
 

--- a/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.java
@@ -58,9 +58,13 @@ public class DockerRepositorySettingsImpl extends AbstractRepositorySettings imp
     }
 
 
-    public Integer getDockerTagRetention() {return dockerTagRetention; }
+    public Integer getDockerTagRetention() {
+        return dockerTagRetention;
+    }
 
-    public void setDockerTagRetention(Integer dockerTagRetention) { this.dockerTagRetention = dockerTagRetention; }
+    public void setDockerTagRetention(Integer dockerTagRetention) {
+        this.dockerTagRetention = dockerTagRetention;
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/DockerRepositorySettingsImpl.java
@@ -57,7 +57,6 @@ public class DockerRepositorySettingsImpl extends AbstractRepositorySettings imp
         this.maxUniqueTags = maxUniqueTags;
     }
 
-
     public Integer getDockerTagRetention() {
         return dockerTagRetention;
     }

--- a/services/src/test/groovy/org/jfrog/artifactory/client/DockerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/DockerPackageTypeRepositoryTests.groovy
@@ -26,6 +26,7 @@ class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
         settings.with {
             // local
             dockerApiVersion = DockerApiVersion.values()[rnd.nextInt(DockerApiVersion.values().length)]
+            dockerTagRetention = Math.abs(rnd.nextInt())
 
             // remote
             enableTokenAuthentication = rnd.nextBoolean()
@@ -55,6 +56,7 @@ class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // local
             assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))
+            assertThat(dockerTagRetention, CoreMatchers.is(expectedSettings.getDockerTagRetention()))
 
             // remote
             assertThat(enableTokenAuthentication, CoreMatchers.is(CoreMatchers.nullValue()))


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----

Followup #348 

* Add getDockerTagRetention to DockerRepositorySettings.java
* Fix identation
* Add test