### PR TITLE
Fix tests

### DIFF
--- a/ci/appveyor.yml
+++ b/ci/appveyor.yml
@@ -7,12 +7,6 @@ environment:
   APPVEYOR_SAVE_CACHE_ON_ERROR: true
   APPVEYOR_YML_DISABLE_PS_LINUX: true
   JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-  CLIENTTESTS_ARTIFACTORY_URL:
-    secure: RIh0gGFDn2JAnLUEEqLsQm0ihToJ6/4LiR411QpvqDgYYE7Y4Eif2e+wYndvHXnW
-  CLIENTTESTS_ARTIFACTORY_USERNAME:
-    secure: YEB5Wiv9a2vNpUhy+MfL+A==
-  CLIENTTESTS_ARTIFACTORY_PASSWORD:
-    secure: Um8o75MQIieSavIemF4ySA==
 
 test_script:
   - sh: ./gradlew test

--- a/services/src/test/groovy/org/jfrog/artifactory/client/BowerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/BowerPackageTypeRepositoryTests.groovy
@@ -116,7 +116,6 @@ class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(bowerRegistryUrl, CoreMatchers.is(expectedSettings.getBowerRegistryUrl()))
             assertThat(vcsGitDownloadUrl, CoreMatchers.is(expectedSettings.getVcsGitDownloadUrl()))
             assertThat(vcsGitProvider, CoreMatchers.is(expectedSettings.getVcsGitProvider()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/CocoaPodsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/CocoaPodsPackageTypeRepositoryTests.groovy
@@ -101,7 +101,6 @@ class CocoaPodsPackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(podsSpecsRepoUrl, CoreMatchers.is(expectedSettings.getPodsSpecsRepoUrl()))
             assertThat(vcsGitDownloadUrl, CoreMatchers.is(expectedSettings.getVcsGitDownloadUrl()))
             assertThat(vcsGitProvider, CoreMatchers.is(expectedSettings.getVcsGitProvider()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/ComposerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/ComposerPackageTypeRepositoryTests.groovy
@@ -90,7 +90,6 @@ class ComposerPackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // remote
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(composerRegistryUrl, CoreMatchers.is(expectedSettings.getComposerRegistryUrl()))
             assertThat(vcsGitDownloadUrl, CoreMatchers.is(expectedSettings.getVcsGitDownloadUrl()))
             assertThat(vcsGitProvider, CoreMatchers.is(expectedSettings.getVcsGitProvider()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/DockerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/DockerPackageTypeRepositoryTests.groovy
@@ -25,7 +25,7 @@ class DockerPackageTypeRepositoryTests extends BaseRepositoryTests {
 
         settings.with {
             // local
-            dockerApiVersion = DockerApiVersion.values()[rnd.nextInt(DockerApiVersion.values().length)]
+            dockerApiVersion = DockerApiVersion.V2
             dockerTagRetention = Math.abs(rnd.nextInt())
 
             // remote

--- a/services/src/test/groovy/org/jfrog/artifactory/client/GradlePackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/GradlePackageTypeRepositoryTests.groovy
@@ -98,8 +98,6 @@ class GradlePackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
             // always in resp payload
             assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
             assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
 

--- a/services/src/test/groovy/org/jfrog/artifactory/client/IvyPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/IvyPackageTypeRepositoryTests.groovy
@@ -98,8 +98,6 @@ class IvyPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
             // always in resp payload
             assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
             assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
             // always sent by artifactory

--- a/services/src/test/groovy/org/jfrog/artifactory/client/MavenPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/MavenPackageTypeRepositoryTests.groovy
@@ -138,8 +138,6 @@ class MavenPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
             // always in resp payload
             assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
             assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
             // always sent by artifactory

--- a/services/src/test/groovy/org/jfrog/artifactory/client/NugetPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/NugetPackageTypeRepositoryTests.groovy
@@ -87,7 +87,6 @@ class NugetPackageTypeRepositoryTests extends BaseRepositoryTests {
 
             // local
             // always in resp payload
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(downloadContextPath, CoreMatchers.is(expectedSettings.getDownloadContextPath()))
             assertThat(feedContextPath, CoreMatchers.is(expectedSettings.getFeedContextPath()))
             assertThat(v3FeedUrl, CoreMatchers.is(expectedSettings.getV3FeedUrl()))

--- a/services/src/test/groovy/org/jfrog/artifactory/client/P2PackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/P2PackageTypeRepositoryTests.groovy
@@ -79,8 +79,6 @@ class P2PackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
             // always in resp payload
             assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
             assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
             // always sent by artifactory

--- a/services/src/test/groovy/org/jfrog/artifactory/client/SbtPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/SbtPackageTypeRepositoryTests.groovy
@@ -98,8 +98,6 @@ class SbtPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(checksumPolicyType, CoreMatchers.nullValue())
             // always in resp payload
             assertThat(handleReleases, CoreMatchers.is(expectedSettings.getHandleReleases()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
             assertThat(snapshotVersionBehavior, CoreMatchers.nullValue())
             assertThat(suppressPomConsistencyChecks, CoreMatchers.is(expectedSettings.getSuppressPomConsistencyChecks()))
             // always sent by artifactory

--- a/services/src/test/groovy/org/jfrog/artifactory/client/VcsPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/VcsPackageTypeRepositoryTests.groovy
@@ -63,7 +63,6 @@ class VcsPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(vcsGitProvider, CoreMatchers.is(expectedSettings.getVcsGitProvider()))
             assertThat(vcsType, CoreMatchers.is(expectedSettings.getVcsType()))
             assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
-            assertThat(maxUniqueSnapshots, CoreMatchers.is(expectedSettings.getMaxUniqueSnapshots()))
         }
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----

* Remove maxUniqueSnapshots comparison on remote repositories - it doesn't make sense to check it on remote repositories.
* Use Docker API version V2, to allow running it on a cloud environment:
>
    org.apache.http.client.HttpResponseException: status code: 400, reason phrase: {
      "errors" : [ {
        "status" : 400,
        "message" : "Docker Repository can't be defined as V1 on Cloud"
      } ]
    }
