### PR TITLE
Fix tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -25,28 +25,23 @@ jobs:
             gradlewSuffix: .bat
     runs-on: ${{ matrix.os }}-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: 1.20.x
-          cache: false
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - name: Setup Artifactory
-        run: |
-          go install github.com/jfrog/jfrog-testing-infra/local-rt-setup@latest
-          ~/go/bin/local-rt-setup
-        env:
-          RTLIC: ${{secrets.RTLIC}}
-          GOPROXY: direct
+      - name: Setup Go with cache
+        uses: jfrog/.github/actions/install-go-with-cache@main
+
+      - name: Install local Artifactory
+        uses: jfrog/.github/actions/install-local-artifactory@main
+        with:
+          RTLIC: ${{ secrets.RTLIC }}
 
       - name: Install Java
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           java-version: "8"
-          distribution: "temurin"
+          distribution: "zulu"
 
       - name: Run tests
         run: ./gradlew${{ matrix.gradlewSuffix }} clean test

--- a/services/src/test/groovy/org/jfrog/artifactory/client/BowerPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/BowerPackageTypeRepositoryTests.groovy
@@ -122,9 +122,9 @@ class BowerPackageTypeRepositoryTests extends BaseRepositoryTests {
             assertThat(vcsType, CoreMatchers.is(expectedSettings.getVcsType()))
 
             // virtual
-            assertFalse(externalDependenciesEnabled)
-            assertThat(externalDependenciesPatterns, CoreMatchers.nullValue())
-            assertThat(externalDependenciesRemoteRepo, CoreMatchers.nullValue())
+            assertThat(externalDependenciesEnabled, CoreMatchers.is(expectedSettings.getExternalDependenciesEnabled()))
+            assertThat(externalDependenciesPatterns, CoreMatchers.is(expectedSettings.getExternalDependenciesPatterns()))
+            assertThat(externalDependenciesRemoteRepo, CoreMatchers.is(expectedSettings.getExternalDependenciesRemoteRepo()))
         }
     }
 

--- a/services/src/test/java/org/jfrog/artifactory/client/SecurityTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/SecurityTests.java
@@ -103,13 +103,10 @@ public class SecurityTests extends ArtifactoryTestsBase {
         PermissionTarget permissionTarget = artifactory.security().permissionTarget("Anything");
         assertEquals("Anything", permissionTarget.getName());
         assertTrue(permissionTarget.getIncludesPattern().contains("**"));
-        assertTrue(permissionTarget.getRepositories().size() > 0);
+        assertFalse(permissionTarget.getRepositories().isEmpty());
+        assertEquals("ANY", permissionTarget.getRepositories().get(0));
         assertNotNull(permissionTarget.getPrincipals());
         assertNotNull(permissionTarget.getPrincipals().getUsers());
-        final String user = permissionTarget.getPrincipals().getUsers().get(0).getName();
-        assertFalse(permissionTarget.getPrincipals().getUser(user).getPrivileges().contains(Privilege.ADMIN));
-        assertFalse(permissionTarget.getPrincipals().getUser(user).getPrivileges().contains(Privilege.DELETE));
-        assertTrue(permissionTarget.getPrincipals().getUser(user).getPrivileges().contains(Privilege.READ));
         assertNotNull(permissionTarget.getPrincipals().getGroups());
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----

- Update `BowerPackageTypeRepositoryTests` to accommodate virtual repositories now supporting `externalDependenciesPatterns`.
- Switch Java distribution to Zulu as Temurin is not supported on Mac ARM64.
- Replace direct usage of `github.com/jfrog/jfrog-testing-infra/local-rt-setup` with `jfrog/.github/actions/install-local-artifactory@main` to ensure the latest working version of Artifactory is used.
- Fix testGetPermissionTarget - Permission targets no longer include a user by default.


Running tests: https://github.com/yahavi/artifactory-client-java/actions/runs/10528512266