### PR TITLE
Add `helmoci` repository support

### DIFF
--- a/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/HelmOciRepositorySettings.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/repository/settings/HelmOciRepositorySettings.java
@@ -1,0 +1,8 @@
+package org.jfrog.artifactory.client.model.repository.settings;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public interface HelmOciRepositorySettings extends DockerRepositorySettings {
+
+}

--- a/services/src/main/java/org/jfrog/artifactory/client/impl/jackson/RepositorySettingsMixIn.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/impl/jackson/RepositorySettingsMixIn.java
@@ -41,6 +41,7 @@ import org.jfrog.artifactory.client.model.repository.settings.impl.*;
     @JsonSubTypes.Type(value = CondaRepositorySettingsImpl.class, name = "conda"),
     @JsonSubTypes.Type(value = PuppetRepositorySettingsImpl.class, name = "puppet"),
     @JsonSubTypes.Type(value = HelmRepositorySettingsImpl.class, name = "helm"),
+    @JsonSubTypes.Type(value = HelmOciRepositorySettingsImpl.class, name = "helmoci"),
     @JsonSubTypes.Type(value = GoRepositorySettingsImpl.class, name = "go"),
     @JsonSubTypes.Type(value = CargoRepositorySettingsImpl.class, name = "cargo"),
     @JsonSubTypes.Type(value = TerraformRepositorySettingsImpl.class, name = "terraform"),

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/FederatedRepositoryBuilderImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/FederatedRepositoryBuilderImpl.java
@@ -16,7 +16,7 @@ import static org.jfrog.artifactory.client.model.impl.PackageTypeImpl.*;
  */
 public class FederatedRepositoryBuilderImpl extends NonVirtualRepositoryBuilderBase<FederatedRepositoryBuilder, FederatedRepository> implements FederatedRepositoryBuilder {
     private static Set<PackageType> federatedRepositorySupportedTypes = new HashSet<>(Arrays.asList(
-            bower, cocoapods, cran, conda, debian, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, pypi, sbt, vagrant, yum, rpm, composer, conan, chef, puppet, helm, go, cargo, terraform, oci
+            bower, cocoapods, cran, conda, debian, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, pypi, sbt, vagrant, yum, rpm, composer, conan, chef, puppet, helm, helmoci, go, cargo, terraform, oci
     ));
 
     protected List<FederatedMember> members = new ArrayList<>();

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalRepositoryBuilderImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/LocalRepositoryBuilderImpl.java
@@ -17,7 +17,7 @@ import static org.jfrog.artifactory.client.model.impl.PackageTypeImpl.*;
  */
 public class LocalRepositoryBuilderImpl extends NonVirtualRepositoryBuilderBase<LocalRepositoryBuilder, LocalRepository> implements LocalRepositoryBuilder {
     private static Set<PackageType> localRepositorySupportedTypes = new HashSet<PackageType>(Arrays.asList(
-            bower, cocoapods, cran, conda, debian, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, pypi, sbt, vagrant, yum, rpm, composer, conan, chef, puppet, helm, go, cargo, terraform, oci
+            bower, cocoapods, cran, conda, debian, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, pypi, sbt, vagrant, yum, rpm, composer, conan, chef, puppet, helm, helmoci, go, cargo, terraform, oci
     ));
 
     protected LocalRepositoryBuilderImpl() {

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/PackageTypeImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/PackageTypeImpl.java
@@ -31,6 +31,7 @@ public enum PackageTypeImpl implements PackageType {
     chef,
     puppet,
     helm,
+    helmoci,
     go,
     cargo,
     terraform,

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/RemoteRepositoryBuilderImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/RemoteRepositoryBuilderImpl.java
@@ -17,7 +17,7 @@ import static org.jfrog.artifactory.client.model.impl.PackageTypeImpl.*;
  */
 public class RemoteRepositoryBuilderImpl extends NonVirtualRepositoryBuilderBase<RemoteRepositoryBuilder, RemoteRepository> implements RemoteRepositoryBuilder {
     private static Set<PackageType> remoteRepositorySupportedTypes = new HashSet<PackageType>(Arrays.asList(
-            bower, cocoapods, cran, conda, debian, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, p2, pypi, sbt, vcs, yum, rpm, composer, conan, chef, puppet, helm, go, cargo, terraform, oci
+            bower, cocoapods, cran, conda, debian, docker, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, opkg, p2, pypi, sbt, vcs, yum, rpm, composer, conan, chef, puppet, helm, helmoci, go, cargo, terraform, oci
     ));
 
     private String url;

--- a/services/src/main/java/org/jfrog/artifactory/client/model/impl/VirtualRepositoryBuilderImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/impl/VirtualRepositoryBuilderImpl.java
@@ -15,7 +15,7 @@ import static org.jfrog.artifactory.client.model.impl.PackageTypeImpl.*;
  */
 public class VirtualRepositoryBuilderImpl extends RepositoryBuilderBase<VirtualRepositoryBuilder, VirtualRepository> implements VirtualRepositoryBuilder {
     private static Set<PackageType> virtualRepositorySupportedTypes = new HashSet<PackageType>(Arrays.asList(
-            bower, cran, conda, docker, debian, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, p2, pypi, sbt, yum, rpm, composer, conan, chef, puppet, helm, go, terraform, oci
+            bower, cran, conda, docker, debian, gems, generic, gitlfs, gradle, ivy, maven, npm, nuget, p2, pypi, sbt, yum, rpm, composer, conan, chef, puppet, helm, helmoci, go, terraform, oci
     ));
 
     private Collection<String> repositories = Collections.emptyList();

--- a/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/HelmOciRepositorySettingsImpl.java
+++ b/services/src/main/java/org/jfrog/artifactory/client/model/repository/settings/impl/HelmOciRepositorySettingsImpl.java
@@ -1,0 +1,21 @@
+package org.jfrog.artifactory.client.model.repository.settings.impl;
+
+import org.jfrog.artifactory.client.model.PackageType;
+import org.jfrog.artifactory.client.model.impl.PackageTypeImpl;
+import org.jfrog.artifactory.client.model.repository.settings.OciRepositorySettings;
+
+public class HelmOciRepositorySettingsImpl extends DockerRepositorySettingsImpl implements OciRepositorySettings {
+    public static String defaultLayout = "simple-default";
+
+    public PackageType getPackageType() {
+        return PackageTypeImpl.helmoci;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof HelmOciRepositorySettingsImpl)) {
+            return false;
+        }
+        return super.equals(o);
+    }
+}

--- a/services/src/main/resources/artifactory.client.release.properties
+++ b/services/src/main/resources/artifactory.client.release.properties
@@ -1,1 +1,1 @@
-version=2.18.0
+version=2.18.x-SNAPSHOT

--- a/services/src/test/groovy/org/jfrog/artifactory/client/HelmOciPackageTypeRepositoryTests.groovy
+++ b/services/src/test/groovy/org/jfrog/artifactory/client/HelmOciPackageTypeRepositoryTests.groovy
@@ -1,0 +1,129 @@
+package org.jfrog.artifactory.client
+
+import org.hamcrest.CoreMatchers
+import org.jfrog.artifactory.client.model.RepositoryType
+import org.jfrog.artifactory.client.model.repository.settings.RepositorySettings
+import org.jfrog.artifactory.client.model.repository.settings.docker.DockerApiVersion
+import org.jfrog.artifactory.client.model.repository.settings.impl.HelmOciRepositorySettingsImpl
+import org.testng.annotations.BeforeMethod
+import org.testng.annotations.Test
+
+/**
+ * test that client correctly sends and receives repository configuration with `helmoci` package type
+ *
+ */
+class HelmOciPackageTypeRepositoryTests extends BaseRepositoryTests {
+
+    HelmOciPackageTypeRepositoryTests() {
+        remoteRepoUrl = "https://registry-1.docker.io"
+    }
+
+    @Override
+    RepositorySettings getRepositorySettings(RepositoryType repositoryType) {
+        def settings = new HelmOciRepositorySettingsImpl()
+
+        settings.with {
+            // local
+            dockerApiVersion = DockerApiVersion.V2
+            dockerTagRetention = Math.abs(rnd.nextInt())
+
+            // remote
+            enableTokenAuthentication = rnd.nextBoolean()
+            listRemoteFolderItems = rnd.nextBoolean()
+        }
+
+        return settings
+    }
+
+    @BeforeMethod
+    protected void setUp() {
+        storeArtifactsLocallyInRemoteRepo = true
+        super.setUp()
+    }
+
+    @Test(groups = "helmOciPackageTypeRepo")
+    void testOciLocalRepo() {
+        artifactory.repositories().create(0, localRepo)
+        def expectedSettings = localRepo.repositorySettings
+
+        def resp = artifactory.repository(localRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(HelmOciRepositorySettingsImpl.defaultLayout))
+        resp.getRepositorySettings().with {
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
+
+            // local
+            assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))
+            assertThat(dockerTagRetention, CoreMatchers.is(expectedSettings.getDockerTagRetention()))
+
+            // remote
+            assertThat(enableTokenAuthentication, CoreMatchers.is(CoreMatchers.nullValue()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(CoreMatchers.nullValue()))
+        }
+    }
+
+    @Test(groups = "helmOciPackageTypeRepo")
+    void testOciFederatedRepo() {
+        artifactory.repositories().create(0, federatedRepo)
+        def expectedSettings = federatedRepo.repositorySettings
+
+        def resp = artifactory.repository(federatedRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(HelmOciRepositorySettingsImpl.defaultLayout))
+        resp.getRepositorySettings().with {
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
+
+            // local
+            assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))
+
+            // remote
+            assertThat(enableTokenAuthentication, CoreMatchers.is(CoreMatchers.nullValue()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(CoreMatchers.nullValue()))
+        }
+    }
+
+    @Test(groups = "helmOciPackageTypeRepo")
+    void testOciRemoteRepo() {
+        artifactory.repositories().create(0, remoteRepo)
+        def expectedSettings = remoteRepo.repositorySettings
+
+        def resp = artifactory.repository(remoteRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(HelmOciRepositorySettingsImpl.defaultLayout))
+        resp.getRepositorySettings().with {
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
+
+            // local
+            assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))
+            // always in resp payload
+
+            // remote
+            assertThat(enableTokenAuthentication, CoreMatchers.is(expectedSettings.getEnableTokenAuthentication()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(expectedSettings.getListRemoteFolderItems()))
+        }
+    }
+
+    @Test(groups = "helmOciPackageTypeRepo")
+    void testDockerVirtualRepo() {
+        artifactory.repositories().create(0, virtualRepo)
+        def expectedSettings = virtualRepo.repositorySettings
+
+        def resp = artifactory.repository(virtualRepo.getKey()).get()
+        assertThat(resp, CoreMatchers.notNullValue())
+        assertThat(resp.repoLayoutRef, CoreMatchers.is(HelmOciRepositorySettingsImpl.defaultLayout))
+        resp.getRepositorySettings().with {
+            assertThat(packageType, CoreMatchers.is(expectedSettings.getPackageType()))
+            assertThat(repoLayout, CoreMatchers.is(expectedSettings.getRepoLayout()))
+
+            // local
+            assertThat(dockerApiVersion, CoreMatchers.is(expectedSettings.getDockerApiVersion()))
+
+            // remote
+            assertThat(enableTokenAuthentication, CoreMatchers.is(CoreMatchers.nullValue()))
+            assertThat(listRemoteFolderItems, CoreMatchers.is(CoreMatchers.nullValue()))
+        }
+    }
+}


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----

Similar to https://github.com/jfrog/artifactory-client-java/pull/387 but for `helmoci` type