### PR TITLE
Upgrade commons-io to 2.17.0

### DIFF
--- a/services/build.gradle
+++ b/services/build.gradle
@@ -7,7 +7,7 @@ dependencies {
     implementation addSlf4J('slf4j-api')
     implementation addSlf4J('log4j-over-slf4j')
     implementation addSlf4J('jcl-over-slf4j')
-    implementation 'commons-io:commons-io:2.8.0'
+    implementation 'commons-io:commons-io:2.17.0'
     testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: '2.2'
     testImplementation group: 'org.testng', name: 'testng', version: '7.5.1'
     /*


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
-----
apache commons: io has [vuln ](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2024-47554) until v2.14:
https://mvnrepository.com/artifact/commons-io/commons-io
