### PR TITLE
added GAVC search for Virtual and Remote Repositories

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,6 +36,7 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
+          VERSION: 7.98.18
 
       - name: Install Java
         uses: actions/setup-java@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          VERSION: 7.98.18
+          VERSION: "7.98.18"
 
       - name: Install Java
         uses: actions/setup-java@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,7 +36,6 @@ jobs:
         uses: jfrog/.github/actions/install-local-artifactory@main
         with:
           RTLIC: ${{ secrets.RTLIC }}
-          VERSION: "7.98.18"
 
       - name: Install Java
         uses: actions/setup-java@v4

--- a/README.md
+++ b/README.md
@@ -368,6 +368,25 @@ for (RepoPath searchItem : searchItems) {
 }
 ```
 
+##### Searching Files by GAVC and Virtual or Remote Repository
+
+```groovy
+List<RepoPath> results = artifactory.searches().artifactsByGavc()
+        .groupId("com.example")
+        .artifactId("com.example.test")
+        .repositories("maven-libs-release")
+        .specific()
+        .doSearch();
+
+for (RepoPath searchItem : searchItems) {
+    String repoKey = searchItem.getRepoKey();
+    String itemPath = searchItem.getItemPath();
+}
+```
+* From Artifactory version 7.37.9, the following
+&specific=true(default false)
+ attribute was added to support virtual and remote repositories. See [here](https://jfrog.com/help/r/jfrog-rest-apis/usage-for-remote-and-virtual-repositories).
+
 ##### Searching Latest Version by GAVC and Repository
 
 ```groovy

--- a/api/src/main/java/org/jfrog/artifactory/client/Searches.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Searches.java
@@ -62,4 +62,7 @@ public interface Searches {
     PropertyFilters itemsByProperty();
 
     List<AqlItem> artifactsByFileSpec(FileSpec fileSpec);
+
+    Searches virtualOrRemote();
+
 }

--- a/api/src/main/java/org/jfrog/artifactory/client/Searches.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/Searches.java
@@ -63,6 +63,6 @@ public interface Searches {
 
     List<AqlItem> artifactsByFileSpec(FileSpec fileSpec);
 
-    Searches virtualOrRemote();
+    Searches specific();
 
 }

--- a/api/src/main/java/org/jfrog/artifactory/client/model/SearchResultReport.java
+++ b/api/src/main/java/org/jfrog/artifactory/client/model/SearchResultReport.java
@@ -9,10 +9,15 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 public class SearchResultReport {
 
     private String uri;
+    private String downloadUri;
     private String created;
 
     public String getUri() {
         return uri;
+    }
+
+    public String getDownloadUri() {
+        return downloadUri;
     }
 
     public String getCreated() {

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/SearchesImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/SearchesImpl.groovy
@@ -96,6 +96,12 @@ class SearchesImpl implements Searches {
         this
     }
 
+    @Override
+    Searches virtualOrRemote() {
+        this.searchQuery << [specific: "true"]
+        this
+    }
+
     List<RepoPath> doSearch() {
         if (!searchUrl) {
             throw new IllegalArgumentException("Search url wasn't set. Please call one of the 'artifacts...' methods before calling 'search()'")
@@ -122,9 +128,15 @@ class SearchesImpl implements Searches {
             String path = Util.getQueryPath("?", query)
             SearchResultImpl searchResults = artifactory.get("${getSearcherApi()}$url$path", SearchResultImpl, SearchResult)
             List<RepoPath> pathList = new ArrayList<>();
+            String fullPath;
             for (SearchResultReport searchResultReport : searchResults.getResults()) {
                 String uri = searchResultReport.getUri();
-                String fullPath = uri.split(baseApiPath + '/storage/')[1]
+                if (uri == null) {
+                    uri = searchResultReport.getDownloadUri()
+                    fullPath = uri.split('/artifactory/')[1]
+                } else {
+                    fullPath = uri.split(baseApiPath + '/storage/')[1]
+                }
                 String repo = fullPath.substring(0,fullPath.indexOf('/'))
                 pathList.add(new RepoPathImpl(repo, fullPath - (repo + '/')))
             }

--- a/services/src/main/groovy/org/jfrog/artifactory/client/impl/SearchesImpl.groovy
+++ b/services/src/main/groovy/org/jfrog/artifactory/client/impl/SearchesImpl.groovy
@@ -97,7 +97,7 @@ class SearchesImpl implements Searches {
     }
 
     @Override
-    Searches virtualOrRemote() {
+    Searches specific() {
         this.searchQuery << [specific: "true"]
         this
     }

--- a/services/src/test/java/org/jfrog/artifactory/client/ArtifactoryTestsBase.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/ArtifactoryTestsBase.java
@@ -11,6 +11,7 @@ import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.jfrog.artifactory.client.model.LocalRepository;
 import org.jfrog.artifactory.client.model.Repository;
+import org.jfrog.artifactory.client.model.VirtualRepository;
 import org.jfrog.artifactory.client.model.repository.settings.impl.MavenRepositorySettingsImpl;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -48,11 +49,13 @@ public abstract class ArtifactoryTestsBase {
     protected String fileMd5;
     protected String fileSha1;
     protected LocalRepository localRepository;
+    protected VirtualRepository virtualRepository;
     protected String federationUrl;
 
     @BeforeClass
     public void init() throws IOException {
         String localRepositoryKey = "java-client-" + getClass().getSimpleName();
+        String virtualRepositoryKey = "java-client-virtual-" + getClass().getSimpleName();
         Properties props = new Properties();
         // This file is not in GitHub. Create your own in src/test/resources.
         InputStream inputStream = this.getClass().getResourceAsStream("/artifactory-client.properties");
@@ -76,6 +79,7 @@ public abstract class ArtifactoryTestsBase {
                 .setPassword(password)
                 .build();
         deleteRepoIfExists(localRepositoryKey);
+        deleteRepoIfExists(virtualRepositoryKey);
         deleteRepoIfExists(getJCenterRepoName());
         localRepository = artifactory.repositories().builders().localRepositoryBuilder()
                 .key(localRepositoryKey)
@@ -84,8 +88,18 @@ public abstract class ArtifactoryTestsBase {
                 .propertySets(Arrays.asList("artifactory"))
                 .build();
 
+        virtualRepository = artifactory.repositories().builders().virtualRepositoryBuilder()
+                .key(virtualRepositoryKey)
+                .description("new virtual repository")
+                .repositorySettings(new MavenRepositorySettingsImpl())
+                .build();
+
         if (!artifactory.repository(localRepository.getKey()).exists()) {
             artifactory.repositories().create(1, localRepository);
+        }
+
+        if (!artifactory.repository(virtualRepository.getKey()).exists()) {
+            artifactory.repositories().create(1, virtualRepository);
         }
 
         String jcenterRepoName = getJCenterRepoName();

--- a/services/src/test/java/org/jfrog/artifactory/client/ArtifactoryTestsBase.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/ArtifactoryTestsBase.java
@@ -21,7 +21,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Properties;
 
 import static org.apache.commons.codec.binary.Base64.encodeBase64;
@@ -88,10 +90,13 @@ public abstract class ArtifactoryTestsBase {
                 .propertySets(Arrays.asList("artifactory"))
                 .build();
 
+        Collection<String> repositories = new ArrayList<>();
+        repositories.add(localRepositoryKey);
         virtualRepository = artifactory.repositories().builders().virtualRepositoryBuilder()
                 .key(virtualRepositoryKey)
                 .description("new virtual repository")
                 .repositorySettings(new MavenRepositorySettingsImpl())
+                .repositories(repositories)
                 .build();
 
         if (!artifactory.repository(localRepository.getKey()).exists()) {

--- a/services/src/test/java/org/jfrog/artifactory/client/ArtifactoryTestsBase.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/ArtifactoryTestsBase.java
@@ -10,6 +10,7 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
 import org.jfrog.artifactory.client.model.LocalRepository;
+import org.jfrog.artifactory.client.model.RemoteRepository;
 import org.jfrog.artifactory.client.model.Repository;
 import org.jfrog.artifactory.client.model.VirtualRepository;
 import org.jfrog.artifactory.client.model.repository.settings.impl.MavenRepositorySettingsImpl;
@@ -52,12 +53,14 @@ public abstract class ArtifactoryTestsBase {
     protected String fileSha1;
     protected LocalRepository localRepository;
     protected VirtualRepository virtualRepository;
+    protected RemoteRepository remoteRepository;
     protected String federationUrl;
 
     @BeforeClass
     public void init() throws IOException {
         String localRepositoryKey = "java-client-" + getClass().getSimpleName();
         String virtualRepositoryKey = "java-client-virtual-" + getClass().getSimpleName();
+        String remoteRepositoryKey = "java-client-remote-" + getClass().getSimpleName();
         Properties props = new Properties();
         // This file is not in GitHub. Create your own in src/test/resources.
         InputStream inputStream = this.getClass().getResourceAsStream("/artifactory-client.properties");
@@ -105,6 +108,17 @@ public abstract class ArtifactoryTestsBase {
 
         if (!artifactory.repository(virtualRepository.getKey()).exists()) {
             artifactory.repositories().create(1, virtualRepository);
+        }
+
+        remoteRepository = artifactory.repositories().builders().remoteRepositoryBuilder()
+                .key(remoteRepositoryKey)
+                .url("https://repo1.maven.org/maven2/")
+                .description("new maven remote repository")
+                .repositorySettings(new MavenRepositorySettingsImpl())
+                .build();
+
+        if (!artifactory.repository(remoteRepository.getKey()).exists()) {
+            artifactory.repositories().create(1, remoteRepository);
         }
 
         String jcenterRepoName = getJCenterRepoName();

--- a/services/src/test/java/org/jfrog/artifactory/client/SearchTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/SearchTests.java
@@ -194,10 +194,24 @@ public class SearchTests extends ArtifactoryTestsBase {
                 .version("1.0.0")
                 .classifier("zip")
                 .repositories(virtualRepository.getKey())
-                .virtualOrRemote()
+                .specific()
                 .doSearch();
         assertEquals(results.size(), 1);
         assertTrue(results.get(0).getItemPath().contains(artifactId + "-1.0.0-zip.jar"));
+    }
+
+    @Test
+    public void testSearchByGavcAndRemoteRepository() throws IOException {
+        List<RepoPath> results = artifactory.searches().artifactsByGavc()
+                .groupId("antlr")
+                .artifactId("antlr")
+                .version("2.7.1")
+                .classifier("jar")
+                .repositories(remoteRepository.getKey())
+                .specific()
+                .doSearch();
+        assertEquals(results.size(), 2);
+        assertTrue(results.get(0).getItemPath().contains("antlr-2.7.1.jar"));
     }
 
     @Test

--- a/services/src/test/java/org/jfrog/artifactory/client/SearchTests.java
+++ b/services/src/test/java/org/jfrog/artifactory/client/SearchTests.java
@@ -187,6 +187,20 @@ public class SearchTests extends ArtifactoryTestsBase {
     }
 
     @Test
+    public void testSearchByGavcAndVirtualRepository() throws IOException {
+        List<RepoPath> results = artifactory.searches().artifactsByGavc()
+                .groupId("com.example")
+                .artifactId(artifactId)
+                .version("1.0.0")
+                .classifier("zip")
+                .repositories(virtualRepository.getKey())
+                .virtualOrRemote()
+                .doSearch();
+        assertEquals(results.size(), 1);
+        assertTrue(results.get(0).getItemPath().contains(artifactId + "-1.0.0-zip.jar"));
+    }
+
+    @Test
     public void testArtifactsCreatedSinceSearch() throws IOException {
         long startTime = System.currentTimeMillis() - 86400000L;
         List<RepoPath> results = artifactory.searches().artifactsCreatedSince(startTime).doSearch();


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
-----

This PR added support for GAVC search for Remote and Virtual repositories [#343](https://github.com/jfrog/artifactory-client-java/issues/343) and [#397](https://github.com/jfrog/artifactory-client-java/issues/397).

When using the GAVC search against Remote or Virtual, the query param "specific=true" should be added, see [here](https://jfrog.com/help/r/jfrog-rest-apis/usage-for-remote-and-virtual-repositories).