### PR TITLE
Updates dependency of jackson because of security finding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,9 +64,9 @@ subprojects {
         }
         implementation 'commons-codec:commons-codec:1.13'
         implementation 'org.apache.commons:commons-lang3:3.12.0'
-        implementation 'com.fasterxml.jackson.core:jackson-core:2.14.1'
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
-        implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.1'
+        implementation 'com.fasterxml.jackson.core:jackson-core:2.19.1'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.19.1'
+        implementation 'com.fasterxml.jackson.core:jackson-annotations:2.19.1'
         api 'org.jfrog.filespecs:file-specs-java:1.1.1'
     }
 


### PR DESCRIPTION
The version 2.14.1 of jackson there is a security issue:

https://github.com/advisories/GHSA-h46c-h94j-95f3

It would be great if you could update to the most recent version 2.19.1 and provide a new version.

Many thanks!

- [ ] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
-----
