### PR TITLE
Fix jackson version security vulnerability

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,9 +64,9 @@ subprojects {
         }
         implementation 'commons-codec:commons-codec:1.13'
         implementation 'org.apache.commons:commons-lang3:3.12.0'
-        implementation 'com.fasterxml.jackson.core:jackson-core:2.14.1'
-        implementation 'com.fasterxml.jackson.core:jackson-databind:2.14.1'
-        implementation 'com.fasterxml.jackson.core:jackson-annotations:2.14.1'
+        implementation 'com.fasterxml.jackson.core:jackson-core:2.19.1'
+        implementation 'com.fasterxml.jackson.core:jackson-databind:2.19.1'
+        implementation 'com.fasterxml.jackson.core:jackson-annotations:2.19.1'
         api 'org.jfrog.filespecs:file-specs-java:1.1.1'
     }
 


### PR DESCRIPTION
- [x] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [x] This pull request is on the dev branch.
-----
## Problem Statement

jackson dependency currently used 2.14.1 is affected with this [security vulnerability](https://github.com/advisories/GHSA-h46c-h94j-95f3).

-----
## Solution
upgrade jackson to 2.19.1 
This PR is to help out #405 since user cant sign CLA.