### PR TITLE
Add explicit Guava and Hamcrest deps missing from wiremock-standalone

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,17 +64,6 @@ subprojects {
     // Force secure versions to fix vulnerabilities
     configurations.all {
         resolutionStrategy {
-            // Force Jetty 12.x (used by wiremock 3.x) - fixes CVE-2026-1225
-            force 'org.eclipse.jetty:jetty-server:12.0.12'
-            force 'org.eclipse.jetty:jetty-http:12.0.12'
-            force 'org.eclipse.jetty:jetty-util:12.0.12'
-            force 'org.eclipse.jetty:jetty-io:12.0.12'
-            force 'org.eclipse.jetty:jetty-client:12.0.12'
-            force 'org.eclipse.jetty:jetty-util-ajax:12.0.12'
-            force 'org.eclipse.jetty:jetty-xml:12.0.12'
-            force 'org.eclipse.jetty.http2:http2-server:12.0.12'
-            force 'org.eclipse.jetty.http2:http2-common:12.0.12'
-            force 'org.eclipse.jetty.http2:http2-hpack:12.0.12'
             // Latest secure versions
             force 'commons-io:commons-io:2.18.0'
             force 'net.minidev:json-smart:2.5.2'

--- a/build.gradle
+++ b/build.gradle
@@ -64,30 +64,17 @@ subprojects {
     // Force secure versions to fix vulnerabilities
     configurations.all {
         resolutionStrategy {
-            // Use latest confirmed available Jetty 9.4.x versions - consistent versions
-            force 'org.eclipse.jetty:jetty-server:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-servlets:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-http:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-util:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-io:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-client:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-security:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-servlet:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-webapp:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-proxy:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-continuation:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-util-ajax:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-xml:9.4.58.v20250814'
-            force 'org.eclipse.jetty.http2:http2-server:9.4.58.v20250814'
-            force 'org.eclipse.jetty.http2:http2-common:9.4.58.v20250814'
-            force 'org.eclipse.jetty.http2:http2-hpack:9.4.58.v20250814'
-            // Force ALPN modules that wiremock depends on
-            force 'org.eclipse.jetty:jetty-alpn-server:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-alpn-java-server:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-alpn-openjdk8-server:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-alpn-java-client:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-alpn-openjdk8-client:9.4.58.v20250814'
-            force 'org.eclipse.jetty:jetty-alpn-client:9.4.58.v20250814'
+            // Force Jetty 12.x (used by wiremock 3.x) - fixes CVE-2026-1225
+            force 'org.eclipse.jetty:jetty-server:12.0.12'
+            force 'org.eclipse.jetty:jetty-http:12.0.12'
+            force 'org.eclipse.jetty:jetty-util:12.0.12'
+            force 'org.eclipse.jetty:jetty-io:12.0.12'
+            force 'org.eclipse.jetty:jetty-client:12.0.12'
+            force 'org.eclipse.jetty:jetty-util-ajax:12.0.12'
+            force 'org.eclipse.jetty:jetty-xml:12.0.12'
+            force 'org.eclipse.jetty.http2:http2-server:12.0.12'
+            force 'org.eclipse.jetty.http2:http2-common:12.0.12'
+            force 'org.eclipse.jetty.http2:http2-hpack:12.0.12'
             // Latest secure versions
             force 'commons-io:commons-io:2.18.0'
             force 'net.minidev:json-smart:2.5.2'

--- a/httpClient/build.gradle
+++ b/httpClient/build.gradle
@@ -8,5 +8,5 @@ repositories {
 
 dependencies {
     testImplementation group: 'org.testng', name: 'testng', version: '7.5.1'
-    testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8', version: '2.35.2'
+    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.12.1'
 }

--- a/httpClient/build.gradle
+++ b/httpClient/build.gradle
@@ -10,3 +10,18 @@ dependencies {
     testImplementation group: 'org.testng', name: 'testng', version: '7.5.1'
     testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.12.1'
 }
+
+// wiremock 3.x requires Java 11+; override test classpath attributes so Gradle
+// resolves it correctly while keeping production code at Java 8
+configurations {
+    testCompileClasspath {
+        attributes {
+            attribute(Attribute.of("org.gradle.jvm.version", Integer), 11)
+        }
+    }
+    testRuntimeClasspath {
+        attributes {
+            attribute(Attribute.of("org.gradle.jvm.version", Integer), 11)
+        }
+    }
+}

--- a/httpClient/build.gradle
+++ b/httpClient/build.gradle
@@ -8,20 +8,5 @@ repositories {
 
 dependencies {
     testImplementation group: 'org.testng', name: 'testng', version: '7.5.1'
-    testImplementation group: 'org.wiremock', name: 'wiremock', version: '3.12.1'
-}
-
-// wiremock 3.x requires Java 11+; override test classpath attributes so Gradle
-// resolves it correctly while keeping production code at Java 8
-configurations {
-    testCompileClasspath {
-        attributes {
-            attribute(Attribute.of("org.gradle.jvm.version", Integer), 11)
-        }
-    }
-    testRuntimeClasspath {
-        attributes {
-            attribute(Attribute.of("org.gradle.jvm.version", Integer), 11)
-        }
-    }
+    testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: '2.35.2'
 }

--- a/httpClient/build.gradle
+++ b/httpClient/build.gradle
@@ -9,4 +9,6 @@ repositories {
 dependencies {
     testImplementation group: 'org.testng', name: 'testng', version: '7.5.1'
     testImplementation group: 'com.github.tomakehurst', name: 'wiremock-jre8-standalone', version: '2.35.2'
+    testImplementation group: 'com.google.guava', name: 'guava', version: '33.4.0-jre'
+    testImplementation group: 'org.hamcrest', name: 'hamcrest-core', version: '2.2'
 }


### PR DESCRIPTION
- [ ] All [tests](https://github.com/jfrog/artifactory-client-java#building-and-testing-the-sources) passed. If this feature is not already covered by the tests, I added new tests.
- [ ] This pull request is on the dev branch.
-----
